### PR TITLE
Only remove type imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { format, Options as PrettierOptions } from 'prettier';
 
 // @ts-expect-error We're only importing so we can create a config item, so we don't care about types
 import bts from '@babel/plugin-transform-typescript';
-const babelTsTransform = createConfigItem(bts);
+const babelTsTransform = createConfigItem([bts, { onlyRemoveTypeImports: true }]);
 
 // @ts-expect-error We're only importing so we can create a config item, so we don't care about types
 import bsd from '@babel/plugin-syntax-decorators';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -126,4 +126,17 @@ export default class Foo extends Component {
 `;
     expect(await removeTypes(contents)).toEqual(expected);
   });
+
+  it("doesn't remove unused imports", async () => {
+    const contents = `import Foo from 'foo';
+
+export default class Baz {}
+`;
+
+    const expected = `import Foo from 'foo';
+
+export default class Baz {}
+`;
+    expect(await removeTypes(contents)).toEqual(expected);
+  });
 });


### PR DESCRIPTION
ember-cli uses `babel-remove-types` for removing types from .gts files and if some of the imported references are only used in the `<template>` context, babel assumes they are unused and removes them.

By enabling the `onlyRemoveTypeImports` option of `@babel/plugin-transform-typescript` those imports are now no longer stripped.

Context on why this is needed: 
- https://github.com/ember-cli/ember-cli/pull/10619
- https://discord.com/channels/480462759797063690/1334098900751093853